### PR TITLE
Bug/10 doesnt link under windows

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -24,13 +24,13 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest] ### Not building on Win, can't build/find grvslib: , windows-latest]
+        os: [ubuntu-latest, windows-latest]
         build_type: [Release]
-        c_compiler: [gcc, clang] #, cl]
+        c_compiler: [gcc, clang, cl]
         include:
-#          - os: windows-latest
-#            c_compiler: cl
-#            cpp_compiler: cl
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++

--- a/grvslib/CMakeLists.txt
+++ b/grvslib/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(concurrency)
 
 add_library(grvslib STATIC)
 target_sources(grvslib
-	PUBLIC
+	PRIVATE
 		linkme.cpp
 )
 target_link_libraries(grvslib

--- a/grvslib/CMakeLists.txt
+++ b/grvslib/CMakeLists.txt
@@ -3,6 +3,10 @@ add_subdirectory(ee)
 add_subdirectory(concurrency)
 
 add_library(grvslib STATIC)
+target_sources(grvslib
+	PUBLIC
+		linkme.cpp
+)
 target_link_libraries(grvslib
 		PRIVATE
 		ee

--- a/grvslib/linkme.cpp
+++ b/grvslib/linkme.cpp
@@ -17,4 +17,4 @@
  */
 
 // This exists solely to get the library to link.
-const char* g_linkme = "linkme";
+extern const char* g_linkme; // = "linkme";

--- a/grvslib/linkme.cpp
+++ b/grvslib/linkme.cpp
@@ -1,0 +1,3 @@
+
+// This exists solely to get the library to link.
+extern const char* g_linkme = "linkme";

--- a/grvslib/linkme.cpp
+++ b/grvslib/linkme.cpp
@@ -16,5 +16,4 @@
  * grvslib.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// This exists solely to get the library to link.
-//extern const char* g_linkme; // = "linkme";
+// DO NOT REMOVE.  This empty file exists to get the library to link properly.

--- a/grvslib/linkme.cpp
+++ b/grvslib/linkme.cpp
@@ -1,3 +1,20 @@
 
+/*
+ * Copyright 2024 Gary R. Van Sickle (grvs@users.sourceforge.net).
+ *
+ * This file is part of grvslib.
+ *
+ * grvslib is free software: you can redistribute it and/or modify it under the
+ * terms of version 3 of the GNU General Public License as published by the Free
+ * Software Foundation.
+ *
+ * grvslib is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * grvslib.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // This exists solely to get the library to link.
-extern const char* g_linkme = "linkme";
+const char* g_linkme = "linkme";

--- a/grvslib/linkme.cpp
+++ b/grvslib/linkme.cpp
@@ -17,4 +17,4 @@
  */
 
 // This exists solely to get the library to link.
-extern const char* g_linkme; // = "linkme";
+//extern const char* g_linkme; // = "linkme";


### PR DESCRIPTION
Added dummy file to top-level lib directory (./grvslib/).  Added Windows back into OS matrix in Github CI action.  Builds on Linux and Windows, passes all GoogleTests.